### PR TITLE
Fix build error with latest STS2 update (ThemeConstants.Label.Font rename)

### DIFF
--- a/SlayTheSpire2.LAN.Multiplayer/Components/CopiedLabel.cs
+++ b/SlayTheSpire2.LAN.Multiplayer/Components/CopiedLabel.cs
@@ -64,7 +64,7 @@ namespace SlayTheSpire2.LAN.Multiplayer.Components
         {
             var locString = new LocString("main_menu_ui", LocKeyPrefix);
             SetTextAutoSize(locString.GetFormattedText());
-            this.ApplyLocaleFontSubstitution(FontType.Regular, ThemeConstants.Label.font);
+            this.ApplyLocaleFontSubstitution(FontType.Regular, ThemeConstants.Label.Font);
         }
     }
 }

--- a/SlayTheSpire2.LAN.Multiplayer/Components/IPAddressLabel.cs
+++ b/SlayTheSpire2.LAN.Multiplayer/Components/IPAddressLabel.cs
@@ -48,7 +48,7 @@ namespace SlayTheSpire2.LAN.Multiplayer.Components
             {
                 var locString = new LocString("main_menu_ui", _locKeyPrefix);
                 SetTextAutoSize(locString.GetFormattedText());
-                this.ApplyLocaleFontSubstitution(FontType.Regular, ThemeConstants.Label.font);
+                this.ApplyLocaleFontSubstitution(FontType.Regular, ThemeConstants.Label.Font);
             }
         }
     }


### PR DESCRIPTION
The latest Slay the Spire 2 update renamed `ThemeConstants.Label.font` to `ThemeConstants.Label.Font` (capital F), causing a build error.

This fixes the two affected files:
- `Components/CopiedLabel.cs`
- `Components/IPAddressLabel.cs`